### PR TITLE
Improve reverse routing.

### DIFF
--- a/tests/TestCase/Routing/Route/I18nRouteTest.php
+++ b/tests/TestCase/Routing/Route/I18nRouteTest.php
@@ -62,7 +62,7 @@ class I18nRouteTest extends TestCase
      */
     public function testUrlWithNamedRoute()
     {
-        Router::connect(
+        Router::createRouteBuilder('/')->connect(
             '/blog/{id}-{slug}',
             ['controller' => 'Posts', 'action' => 'show'],
             [
@@ -77,6 +77,26 @@ class I18nRouteTest extends TestCase
         $request = $request->withParam('lang', 'en')
             ->withParam('controller', 'Posts')
             ->withParam('action', 'index');
+        Router::setRequest($request);
+
+        $result = Router::url(['_name' => 'blog_show', 'id' => '123', 'slug' => 'hello']);
+        $this->assertEquals('/en/blog/123-hello', $result);
+    }
+
+    public function testRouteMatchingWithoutPersistedLang()
+    {
+        Router::createRouteBuilder('/')->connect(
+            '/blog/{id}-{slug}',
+            ['controller' => 'Posts', 'action' => 'show'],
+            [
+                'id' => '\d+',
+                'slug' => '[0-9A-Za-z\-]+',
+                'pass' => ['id', 'slug'],
+                '_name' => 'blog_show',
+                'routeClass' => 'ADmad/I18n.I18nRoute',
+            ]
+        );
+        $request = new ServerRequest();
         Router::setRequest($request);
 
         $result = Router::url(['_name' => 'blog_show', 'id' => '123', 'slug' => 'hello']);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,3 +35,5 @@ define('PLUGIN_TESTS', $root . DS . 'tests' . DS);
 Configure::write('App.paths.plugins', [PLUGIN_TESTS . 'test_app' . DS . 'plugins' . DS]);
 
 Plugin::getCollection()->add(new \ADmad\I18n\Plugin());
+
+Configure::write('Error.ignoredDeprecationPaths', ['src/TestSuite/Fixture/FixtureInjector.php']);


### PR DESCRIPTION
When reverse routing if the persistent "lang" var is not set for current request
(which happens when current URL does not match any route) use the 1st lang from
the langs list to prevent errors for named routes.