### PR TITLE
Fix plural translation collapse in DbMessagesLoader

### DIFF
--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -116,8 +116,12 @@ class DbMessagesLoader
         $item = $results->first();
         // There are max 6 plural forms possible but most people won't need
         // that so will only have the required number of value_{n} fields in db.
+        // Detect the number of plural forms from the selected columns, not from
+        // the values: a singular-only first row has NULL plural values, so
+        // isset() would report 0 forms and collapse every plural to its
+        // singular value (value_0).
         for ($i = 5; $i > 0; $i--) {
-            if (isset($item['value_' . $i])) {
+            if (array_key_exists('value_' . $i, $item)) {
                 $pluralForms = $i;
                 break;
             }

--- a/src/I18n/DbMessagesLoader.php
+++ b/src/I18n/DbMessagesLoader.php
@@ -114,16 +114,14 @@ class DbMessagesLoader
         $messages = [];
         $pluralForms = 0;
         $item = $results->first();
-        // There are max 6 plural forms possible but most people won't need
-        // that so will only have the required number of value_{n} fields in db.
-        // Detect the number of plural forms from the selected columns, not from
-        // the values: a singular-only first row has NULL plural values, so
-        // isset() would report 0 forms and collapse every plural to its
-        // singular value (value_0).
-        for ($i = 5; $i > 0; $i--) {
-            if (array_key_exists('value_' . $i, $item)) {
-                $pluralForms = $i;
-                break;
+        // Count plural forms from the selected columns, not the values: a
+        // singular-only first row has NULL values and would report 0 forms.
+        if (is_array($item)) {
+            for ($i = 5; $i > 0; $i--) {
+                if (array_key_exists('value_' . $i, $item)) {
+                    $pluralForms = $i;
+                    break;
+                }
             }
         }
 

--- a/tests/Fixture/I18nMessagesFixture.php
+++ b/tests/Fixture/I18nMessagesFixture.php
@@ -34,5 +34,15 @@ class I18nMessagesFixture extends TestFixture
             'domain' => 'w_context', 'locale' => 'en', 'context' => 'c2', 'singular' => 'singular',
             'plural' => 'plural', 'value_0' => '{0} value c2', 'value_1' => '{0} values c2',
         ],
+        // Singular-only row with a NULL plural value returned *before* the
+        // plural row. Reproduces the plural-form detection bug.
+        [
+            'domain' => 'plural_order', 'locale' => 'en', 'context' => '', 'singular' => 'first',
+            'plural' => '', 'value_0' => 'first value', 'value_1' => null,
+        ],
+        [
+            'domain' => 'plural_order', 'locale' => 'en', 'context' => '', 'singular' => 'singular',
+            'plural' => 'plural', 'value_0' => '{0} value', 'value_1' => '{0} values',
+        ],
     ];
 }

--- a/tests/TestCase/I18n/DbMessagesLoaderTest.php
+++ b/tests/TestCase/I18n/DbMessagesLoaderTest.php
@@ -82,6 +82,18 @@ class DbMessagesLoaderTest extends TestCase
                     ],
                 ],
             ],
+            // A singular-only row returned before the plural row must not make
+            // the plural collapse to its singular value.
+            [
+                'plural_order',
+                'en',
+                null,
+                [
+                    'first' => 'first value',
+                    'singular' => '{0} value',
+                    'plural' => ['{0} value', '{0} values'],
+                ],
+            ],
             [
                 'foo',
                 'bar',


### PR DESCRIPTION
Fixes #80 (originally reported as cakephp/cakephp#19503).

`DbMessagesLoader::_messages()` detected the number of plural forms from the **values** of the first result row using `isset()`. When that first row is a singular-only message, its `value_1`+ columns are `NULL`, so `isset()` reports zero plural forms. Every plural message then collapses to its singular value (`value_0`), and the real plural form in `value_1` is silently dropped.

Because it depends on row order, the bug only triggers when a singular-only row is returned before a plural row, which is why it looks intermittent.

### Change

- Detect plural forms from the selected **columns** via `array_key_exists()` instead of the values - null-safe and order-independent.
- Add a regression test: a singular-only row (with a `NULL` plural value) returned before a plural row. The existing fixtures masked the bug by storing empty strings (`''`) instead of `NULL`, for which `isset()` is true.
